### PR TITLE
Screenshot Utils

### DIFF
--- a/Docs/CollectionExtensions.md
+++ b/Docs/CollectionExtensions.md
@@ -1,0 +1,4 @@
+# CollectionExtensions
+
+Coming Soon!
+

--- a/Docs/CollectionExtensions.md.meta
+++ b/Docs/CollectionExtensions.md.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95afce37fe87bd6439fa647f4b3fa18a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/GameObjectExtensions.md
+++ b/Docs/GameObjectExtensions.md
@@ -1,0 +1,4 @@
+﻿# GameObjectExtensions
+
+Coming Soon!
+

--- a/Docs/GameObjectExtensions.md.meta
+++ b/Docs/GameObjectExtensions.md.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46f1c2cd5d6d79046b26fba7342f8125
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Docs/TransformExtensions.md
+++ b/Docs/TransformExtensions.md
@@ -1,0 +1,4 @@
+﻿# GameObjectExtensions
+
+Coming Soon!
+

--- a/Docs/TransformExtensions.md.meta
+++ b/Docs/TransformExtensions.md.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 545d19c50f9fdc84fa1f080d2449c1f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/CollectionExtensions.cs
+++ b/Scripts/CollectionExtensions.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DUCK.Utils
+{
+	/// <summary>
+	/// Helper functions designed to improve collections usage.
+	/// </summary>
+	public static class CollectionExtensions
+	{
+		/// <summary>
+		/// Returns a random element from collection
+		/// Picks between 0 and size of collection
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="collection"></param>
+		/// <returns></returns>
+		public static T Random<T>(this IEnumerable<T> collection)
+		{
+			var enumerable = collection as T[] ?? collection.ToArray();
+			if (enumerable.Length == 0)
+			{
+				throw new IndexOutOfRangeException(collection + ": Cannot get a random element from an empty collection!");
+			}
+			return enumerable.ElementAt(UnityEngine.Random.Range(0, enumerable.Length));
+		}
+
+		/// <summary>
+		/// Shuffle calls ShuffleCollection and take a seed for the random number
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="collection"></param>
+		/// <param name="seed"></param>
+		/// <returns></returns>
+		public static T[] Shuffle<T>(this IEnumerable<T> collection, int seed)
+		{
+			var random = new Random(seed);
+			var shuffledArray = ShuffleCollection(collection, random);
+			return shuffledArray;
+		}
+
+		/// <summary>
+		/// Shuffle calls ShuffleCollection and creates an instance of Random using it's default seed
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="collection"></param>
+		/// <returns></returns>
+		public static T[] Shuffle<T>(this IEnumerable<T> collection)
+		{
+			var random = new Random();
+			var shuffledArray = ShuffleCollection(collection, random);
+			return shuffledArray;
+		}
+
+		/// <summary>
+		/// Call from Shuffle and shuffles given collection using Fisher-Yates algorithm
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="collection"></param>
+		/// <param name="random"></param>
+		/// <returns></returns>
+		private static T[] ShuffleCollection<T>(this IEnumerable<T> collection, Random random)
+		{
+			var newArray = collection.ToArray();
+
+			for (var i = newArray.Length; i > 1; i--)
+			{
+				var j = random.Next(i);
+				var tmp = newArray[j];
+				newArray[j] = newArray[i - 1];
+				newArray[i - 1] = tmp;
+			}
+
+			return newArray;
+		}
+
+		/// <summary>
+		/// Loop over collection and call action on each object.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="enumeration"></param>
+		/// <param name="action"></param>
+		public static void ForEach<T>(this IEnumerable<T> enumeration, Action<T> action)
+		{
+			if (action == null)
+			{
+				throw new ArgumentNullException("action");
+			}
+
+			foreach (var item in enumeration)
+			{
+				action.Invoke(item);
+			}
+		}
+
+		/// <summary>
+		/// Returns the list as an array, from a specified startIndex and count
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="collection"></param>
+		/// <param name="startIndex"></param>
+		/// <param name="count"></param>
+		/// <returns></returns>
+		public static T[] ToArray<T>(this List<T> collection, int startIndex = 0, int count = int.MaxValue)
+		{
+			if (startIndex < 0) throw new ArgumentOutOfRangeException("startIndex", "Cannot be negative.");
+			if (count < 0) throw new ArgumentOutOfRangeException("count", "Cannot be negative.");
+			if (startIndex + count > collection.Count) throw new ArgumentOutOfRangeException("count", "startIndex + count > this.Count");
+
+			var array = new T[count];
+			for (var i = 0; i < count; i++)
+			{
+				array[i] = collection[i + startIndex];
+			}
+
+			return array;
+		}
+	}
+}

--- a/Scripts/CollectionExtensions.cs.meta
+++ b/Scripts/CollectionExtensions.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 00104660055d773479b674d91ad1b611
+timeCreated: 1454341764
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/GameObjectExtensions.cs
+++ b/Scripts/GameObjectExtensions.cs
@@ -1,0 +1,52 @@
+﻿using UnityEngine;
+
+namespace DUCK.Utils
+{
+	public static class GameObjectExtensions
+	{
+		/// <summary>
+		/// Returns true if game object is in view of given camera
+		/// </summary>
+		/// <param name="gameObject"></param>
+		/// <param name="camera"></param>
+		/// <returns></returns>
+		public static bool IsInViewOf(this GameObject gameObject, Camera camera)
+		{
+			return gameObject.transform.IsInViewOf(camera);
+		}
+
+		/// <summary>
+		/// Creates a new child object of this game object, that has the given component and the name of that component
+		/// </summary>
+		/// <param name="obj">The target game object</param>
+		/// <param name="worldPositionStays">If true, the parent-relative position, scale and
+		/// rotation are modified such that the object keeps the same world space position,
+		/// rotation and scale as before.</param>
+		/// <typeparam name="TComponent">The component to add to the child game object</typeparam>
+		/// <returns>The newly created component</returns>
+		public static TComponent AddChildWithComponent<TComponent>(this GameObject obj, bool worldPositionStays = true)
+			where TComponent : Component
+		{
+			var component = new GameObject(typeof(TComponent).Name).AddComponent<TComponent>();
+			component.transform.SetParent(obj.transform, worldPositionStays);
+			return component;
+		}
+
+		/// <summary>
+		/// Instantiates a prefab from resources and adds it as a child of this game object
+		/// </summary>
+		/// <param name="obj">The target game object</param>
+		/// <param name="path">The path of the resource to load</param>
+		/// <param name="worldPositionStays">If true, the parent-relative position, scale and
+		/// rotation are modified such that the object keeps the same world space position,
+		/// rotation and scale as before.</param>
+		/// <typeparam name="TComponent">The type of component expected on the prefab and that will be returned</typeparam>
+		/// <returns>The TComponent found on the prefab</returns>
+		public static TComponent AddResourceChild<TComponent>(this GameObject obj, string path,
+			bool worldPositionStays = true)
+			where TComponent : Component
+		{
+			return Instantiator.InstantiateResource<TComponent>(path, obj.transform, worldPositionStays);
+		}
+	}
+}

--- a/Scripts/GameObjectExtensions.cs.meta
+++ b/Scripts/GameObjectExtensions.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 305f15d557185c149b13080088370357
+timeCreated: 1455275213
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Instantiator.cs
+++ b/Scripts/Instantiator.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace DUCK.Utils
+{
+	/// <summary>
+	/// Instantiator is a helper class which can speed up the resource loading / initialising (for your code).
+	/// </summary>
+	public static class Instantiator
+	{
+		/// <summary>
+		/// Instantiates an unloaded Object in the Resources folder.
+		/// Then return the Object.
+		/// </summary>
+		/// <param name="path">The path to the Object inside the resource folder</param>
+		/// <param name="parent">The transform to be set as the parent for the new Object</param>
+		/// <param name="worldPositionStays">Makes the world position stay when it attaches onto the parent transform</param>
+		/// <returns>The instantiated (GameObject's) Component</returns>
+		public static T InstantiateResource<T>(string path, Transform parent = null, bool worldPositionStays = true)
+			where T : Object
+		{
+			var loadedObject = Resources.Load<T>(path);
+			if (loadedObject == null)
+			{
+				throw new Exception("Could not find resource (" + typeof(T).Name + ") in " + path);
+			}
+			return Instantiate(loadedObject, parent, worldPositionStays);
+		}
+
+		/// <summary>
+		/// Load a resource in the Resources folder, return the request.
+		/// Then instantiate the resource, invoke the callback.
+		/// </summary>
+		/// <param name="path">The path to the Object inside the resource folder</param>
+		/// <param name="onLoadCompete">The callback function on resource load</param>
+		/// <param name="parent">The transform to be set as the parent for the new Object</param>
+		/// <param name="worldPositionStays">Makes the world position stay when it attaches onto the parent transform</param>
+		/// <typeparam name="T">Any Component</typeparam>
+		/// <returns>The resource request it created</returns>
+		public static ResourceRequest InstantiateResourceAsync<T>(string path, Action<T> onLoadCompete, Transform parent = null, bool worldPositionStays = true)
+			where T : Object
+		{
+			return LoadResourceAsync<T>(path, loadedObject => onLoadCompete(Instantiate(loadedObject, parent, worldPositionStays)));
+		}
+
+		/// <summary>
+		/// Instantiates the Component on a loaded GameObject, renames and sets its parent.
+		/// </summary>
+		/// <typeparam name="T">Type of object</typeparam>
+		/// <param name="obj">The target object</param>
+		/// <param name="parent">The transform to be set as the parent for the new Object</param>
+		/// <param name="worldPositionStays">Makes the world position stay when it attaches onto the parent transform</param>
+		/// <returns>The new instantiated version of the obj</returns>
+		public static T Instantiate<T>(T obj, Transform parent = null, bool worldPositionStays = true)
+			where T : Object
+		{
+			if (obj == null)
+			{
+				throw new Exception("Loaded object cannot be null");
+			}
+			var instantiateComponent = Object.Instantiate(obj, parent, worldPositionStays);
+			instantiateComponent.name = obj.name;
+			return instantiateComponent;
+		}
+
+		/// <summary>
+		/// Load a resource in the Resources folder, return the request.
+		/// Then do the callback after it is loaded.
+		/// </summary>
+		/// <param name="path">The path to the Object inside the resource folder</param>
+		/// <param name="onLoadCompete">The callback function on resource load</param>
+		/// <typeparam name="T">Any Object</typeparam>
+		/// <returns>The Resource Request</returns>
+		/// <exception cref="Exception">Invalid path</exception>
+		public static ResourceRequest LoadResourceAsync<T>(string path, Action<T> onLoadCompete)
+			where T : Object
+		{
+			var request = Resources.LoadAsync<T>(path);
+			if (request.asset == null && request.isDone)
+			{
+				throw new Exception("Could not find resource (" + typeof(T).Name + ") in " + path);
+			}
+			MonoBehaviourService.Instance.StartCoroutine(UpdateAsyncProgress(request, () => onLoadCompete((T)request.asset)));
+			return request;
+		}
+
+		/// <summary>
+		/// A helper (for coroutine) that callback when an async operation is done.
+		/// </summary>
+		/// <param name="request">Target async operation</param>
+		/// <param name="onLoadCompelte">Callback function when the async operation is done</param>
+		private static IEnumerator UpdateAsyncProgress(AsyncOperation request, Action onLoadCompelte)
+		{
+			yield return new WaitUntil(() => request.isDone);
+			onLoadCompelte();
+		}
+	}
+}

--- a/Scripts/Instantiator.cs.meta
+++ b/Scripts/Instantiator.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b517e31076589bb43bf70ed16053ca29
+timeCreated: 1481825140
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/ScreenshotUtils.meta
+++ b/Scripts/ScreenshotUtils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 25b0ff161758e7a459fdca4b7cc1347a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/ScreenshotUtils/CameraExtensions.cs
+++ b/Scripts/ScreenshotUtils/CameraExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using UnityEngine;
+
+namespace DUCK.Utils.ScreenshotUtils
+{
+	public static class CameraExtensions
+	{
+		private const string INVALID_SIZE_MESSAGE = "width & height must both be above 0";
+
+		/// <summary>
+		/// Renders the camera's viewport into a texture
+		/// </summary>
+		/// <param name="camera">The camera to use</param>
+		/// <param name="width">The width of the texture</param>
+		/// <param name="height">The height of the texture</param>
+		/// <param name="textureFormat">The texture format</param>
+		/// <param name="cullingMask">The culling mask used during the render</param>
+		/// <returns>A Texture2D object of the given width/height</returns>
+		public static Texture2D RenderToTexture(this Camera camera, int width, int height,
+			TextureFormat textureFormat = TextureFormat.ARGB32, int cullingMask = 0)
+		{
+			if (camera == null) throw new ArgumentNullException("camera");
+			if (width <= 0) throw new ArgumentException(INVALID_SIZE_MESSAGE);
+			if (height <= 0) throw new ArgumentException(INVALID_SIZE_MESSAGE);
+
+			var renderTexture = new RenderTexture(width, height, 24);
+			var screenShot = new Texture2D(width, height, textureFormat, false);
+
+			var prevCullingMask = camera.cullingMask;
+			if (cullingMask > 0)
+			{
+				camera.cullingMask = cullingMask;
+			}
+
+			var prevTargetTexture = camera.targetTexture;
+
+			camera.targetTexture = renderTexture;
+			camera.Render();
+			camera.targetTexture = prevTargetTexture;
+			camera.cullingMask = prevCullingMask;
+
+			RenderTexture.active = renderTexture;
+			screenShot.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+			screenShot.Apply();
+			RenderTexture.active = null;
+
+			renderTexture.Release();
+
+			return screenShot;
+		}
+	}
+}

--- a/Scripts/ScreenshotUtils/CameraExtensions.cs.meta
+++ b/Scripts/ScreenshotUtils/CameraExtensions.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 4ea1b7d45235ac94cabfeccfa772e6e7
+timeCreated: 1516981965
+licenseType: Pro
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/ScreenshotUtils/ScreenshotWindow.cs
+++ b/Scripts/ScreenshotUtils/ScreenshotWindow.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace DUCK.Utils.ScreenshotUtils
+{
+	public class RenderToFile : EditorWindow
+	{
+		private enum FileFormat
+		{
+			PNG,
+			JPEG,
+		}
+
+		private Camera renderCamera;
+		private FileFormat fileFileFormat;
+		private TextureFormat textureFormat = TextureFormat.ARGB32;
+		private int jpegQuality = 75;
+		private int width = 512;
+		private int height = 512;
+		private bool nameRendersByDate;
+		private string lastPath;
+
+		[MenuItem("DUCK/Render to File/Show Window", false)]
+		public static void ShowWindow()
+		{
+			GetWindow<RenderToFile>(false, "Render to File", true);
+		}
+
+		private void Awake()
+		{
+			EditorApplication.update += Repaint;
+		}
+
+		private void OnDestroy()
+		{
+			EditorApplication.update -= Repaint;
+		}
+
+		private void OnGUI()
+		{
+			Camera camera = null;
+
+			renderCamera = EditorGUILayout.ObjectField("Render Camera", renderCamera, typeof(Camera), true) as Camera;
+
+			if (renderCamera == null)
+			{
+				if (SceneView.lastActiveSceneView != null)
+				{
+					camera = SceneView.lastActiveSceneView.camera;
+					EditorGUILayout.HelpBox("If you don't choose a render camera, the scene camera will be used. It is recommended to use a real camera", MessageType.Warning);
+				}
+				else
+				{
+					EditorGUILayout.HelpBox("No valid cameras found to render, please assign a camera or open a scene view", MessageType.Warning);
+					return;
+				}
+			}
+			else
+			{
+				camera = renderCamera;
+			}
+
+			var renderTexture = camera.targetTexture;
+
+			fileFileFormat = (FileFormat)EditorGUILayout.EnumPopup("Format", fileFileFormat);
+			if (fileFileFormat == FileFormat.JPEG)
+			{
+				RenderJPEGOptions();
+			}
+
+			textureFormat = (TextureFormat)EditorGUILayout.EnumPopup("Texture Format", textureFormat);
+
+			EditorGUILayout.BeginHorizontal();
+			width = EditorGUILayout.IntField("Width", width);
+			height = EditorGUILayout.IntField("Height", height);
+			EditorGUILayout.EndHorizontal();
+
+			EditorGUILayout.Space();
+			nameRendersByDate = EditorGUILayout.ToggleLeft("Name Renders By Date", nameRendersByDate);
+			if (nameRendersByDate)
+			{
+				lastPath = EditorGUILayout.TextField("Output Directory", lastPath);
+				if (GUILayout.Button("Choose Path"))
+				{
+					lastPath = EditorUtility.OpenFolderPanel(
+						"Select Directory",
+						string.IsNullOrEmpty(lastPath) ? Application.dataPath : lastPath, "Screenshots");
+				}
+			}
+
+			EditorGUILayout.Space();
+			if (GUILayout.Button("Render"))
+			{
+				string path = "";
+				if (nameRendersByDate)
+				{
+					path = lastPath + "/Render_" + DateTime.Now.ToString("yyyy-MM-dd_hh-mm-ss");
+					path += fileFileFormat == FileFormat.PNG ? ".png" : ".jpeg";
+				}
+				else
+				{
+					var currentObj = Selection.activeObject;
+					var filename = currentObj == null ? "Render" : currentObj.name;
+					filename = filename.ToLower().Replace(' ', '_');
+
+					path = EditorUtility.SaveFilePanel(
+						"Save as",
+						string.IsNullOrEmpty(lastPath) ? Application.dataPath : lastPath,
+						filename,
+						fileFileFormat == FileFormat.PNG ? "png" : "jpeg");
+
+					lastPath = path;
+				}
+
+				Debug.Log("Outputting to: " + path);
+				Debug.Log("Last Path: " + lastPath);
+
+				if (string.IsNullOrEmpty(path))
+				{
+					return;
+				}
+
+				var texture = camera.RenderToTexture(width, height, textureFormat);
+				var imageData = fileFileFormat == FileFormat.PNG ? texture.EncodeToPNG() : texture.EncodeToJPG(jpegQuality);
+				File.WriteAllBytes(path, imageData);
+				DestroyImmediate(texture);
+
+				AssetDatabase.Refresh();
+			}
+		}
+
+		private void RenderJPEGOptions()
+		{
+			jpegQuality = EditorGUILayout.IntSlider("JPEG Quality", jpegQuality, 1, 100);
+		}
+	}
+}

--- a/Scripts/ScreenshotUtils/ScreenshotWindow.cs.meta
+++ b/Scripts/ScreenshotUtils/ScreenshotWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 397f15c295f9740449493693a4673df5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/TransformExtensions.cs
+++ b/Scripts/TransformExtensions.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace DUCK.Utils
+{
+	public static class TransformExtensions
+	{
+		/// <summary>
+		/// Destroy all children in this transform
+		/// </summary>
+		/// <param name="transform"></param>
+		public static void DestroyAllChildren(this Transform transform)
+		{
+			var isRuntime = Application.isPlaying;
+			foreach (Transform child in transform)
+			{
+				//Check to see if using method while not in runtime mode
+				if (isRuntime)
+				{
+					Object.Destroy(child.gameObject);
+				}
+				else
+				{
+					Object.DestroyImmediate(child.gameObject);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Loop over each child and call function with child as parameter
+		/// </summary>
+		/// <param name="transform"></param>
+		/// <param name="action"></param>
+		public static void ForEach(this Transform transform, Action<Transform> action)
+		{
+			if (action == null)
+			{
+				throw new ArgumentNullException("action");
+			}
+
+			foreach (Transform child in transform)
+			{
+				action.Invoke(child);
+			}
+		}
+
+		/// <summary>
+		/// Returns true if the transform is in view of the given camera screen space
+		/// </summary>
+		/// <param name="transform"></param>
+		/// <param name="camera"></param>
+		/// <returns></returns>
+		public static bool IsInViewOf(this Transform transform, Camera camera)
+		{
+			if (camera == null)
+			{
+				throw new ArgumentNullException("camera");
+			}
+
+			if (transform == null)
+			{
+				throw new ArgumentNullException("transform");
+			}
+
+			var screenPoint = camera.WorldToViewportPoint(transform.position);
+			return (screenPoint.z > 0 && screenPoint.x > 0 && screenPoint.x < 1 && screenPoint.y > 0 && screenPoint.y < 1);
+		}
+
+		/// <summary>
+		/// Reset the transform position, rotation and local scale to default.
+		/// </summary>
+		public static void Reset(this Transform transform, bool local = false)
+		{
+			if (local)
+			{
+				transform.localPosition = Vector3.zero;
+				transform.localRotation = Quaternion.identity;
+			}
+			else
+			{
+				transform.position = Vector3.zero;
+				transform.rotation = Quaternion.identity;
+			}
+
+			transform.localScale = Vector3.one;
+		}
+
+		/// <summary>
+		/// Set a pivot of a rect tranform
+		/// </summary>
+		/// <param name="transform">The Rect Tranform, will not work if it is not</param>
+		/// <param name="pivot">The new pivot point</param>
+		/// <param name="worldPositionStays">Is the Transform keeps the same position or not</param>
+		public static void SetPivot(this Transform transform, Vector2 pivot, bool worldPositionStays = true)
+		{
+			var rectTransform = transform as RectTransform;
+			if (rectTransform == null) return;
+
+			if (worldPositionStays)
+			{
+				var delta = pivot - rectTransform.pivot;
+				delta.Scale(rectTransform.rect.size);
+				delta.Scale(rectTransform.localScale);
+				rectTransform.anchoredPosition += delta;
+			}
+
+			rectTransform.pivot = pivot;
+		}
+
+		/// <summary>
+		/// Creates a new child object of this transform, that has the given component and
+		/// the name of that component.
+		/// </summary>
+		/// <param name="transform">The target transform</param>
+		/// <param name="worldPositionStays">If true, the parent-relative position, scale and
+		/// rotation are modified such that the object keeps the same world space position,
+		/// rotation and scale as before.</param>
+		/// <typeparam name="TComponent">The component to add to the child game object</typeparam>
+		/// <returns>The newly created component</returns>
+		public static TComponent AddChildWithComponent<TComponent>(this Transform transform, bool worldPositionStays = true)
+			where TComponent : Component
+		{
+			var component = new GameObject(typeof(TComponent).Name).AddComponent<TComponent>();
+			component.transform.SetParent(transform, worldPositionStays);
+			return component;
+		}
+
+		/// <summary>
+		/// Instantiates a prefab from resources and adds it as a child of this transform
+		/// </summary>
+		/// <param name="obj">The target transform</param>
+		/// <param name="path">The path of the resource to load</param>
+		/// <param name="worldPositionStays">If true, the parent-relative position, scale and
+		/// rotation are modified such that the object keeps the same world space position,
+		/// rotation and scale as before.</param>
+		/// <typeparam name="TComponent">The type of component expected on the prefab and that will be returned</typeparam>
+		/// <returns>The TComponent found on the prefab</returns>
+		public static TComponent AddResourceChild<TComponent>(this Transform transform, string path,
+			bool worldPositionStays = true)
+			where TComponent : Component
+		{
+			return Instantiator.InstantiateResource<TComponent>(path, transform, worldPositionStays);
+		}
+
+		/// <summary>
+		/// Take a snapshot of a transform in its current state in this frame.
+		/// </summary>
+		/// <param name="transform"></param>
+		/// <returns></returns>
+		public static TransformSnapshot Snapshot(this Transform transform)
+		{
+			return new TransformSnapshot(transform);
+		}
+
+		public static void ApplySnapshot(this Transform transform, TransformSnapshot snapshot)
+		{
+			snapshot.ApplyTo(transform);
+		}
+	}
+}

--- a/Scripts/TransformExtensions.cs.meta
+++ b/Scripts/TransformExtensions.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: e426ae3218c2e244badae2e8e27b45f2
+timeCreated: 1454503295
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
So the old RenderToFile window & camera extensions `.TakeScreenshot` have been merged into one.

Now you can use `camera.RenderToTexture(width, height, format)` to take a screenshot from that camera at runtime or editor time. 

If you just want a screenshot in editor you can open the window and render from any camera. Better still it now even supports the scene camera!

Both support any texture format in JPEG & PNG, and you can render at any resolution.

![image](https://user-images.githubusercontent.com/5612566/44913222-a399e580-ad24-11e8-8032-95e0b550e427.png)
