### PR TITLE
Wrapped screenshot window into editor scripting define

### DIFF
--- a/Scripts/ScreenshotUtils/ScreenshotWindow.cs
+++ b/Scripts/ScreenshotUtils/ScreenshotWindow.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
@@ -137,3 +138,4 @@ namespace DUCK.Utils.ScreenshotUtils
 		}
 	}
 }
+#endif


### PR DESCRIPTION
This code is an editor window but currently housed in the runtime assembly. As a quick fix I just wrapped it into `#if UNITY_EDITOR`

I would rather move this into a  editor assembly. There is currently no standard in our packages about how to deal with such situations. There are probably different examples. Some may use `Editor` folders, some may use specific assemblies, but there isn't a standard. I don't want to do this until we define one. This is a hotfix and is blocking so I'd rather get this in as is right now. In the meantime we can discuss the standard
